### PR TITLE
The use of filepath functions forced use of the os filesystem, ignori…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/jdkeke142/lingo-toml
 
 go 1.14
 
-require github.com/BurntSushi/toml v0.3.1
+require (
+	github.com/BurntSushi/toml v0.3.1
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=

--- a/lingo.go
+++ b/lingo.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/shurcooL/httpfs/vfsutil"
 )
 
 func OSFS() http.FileSystem {
@@ -44,7 +45,7 @@ func New(deflt, path string, fs http.FileSystem) (*Lingo, error) {
 		deflt:     deflt,
 		supported: make([]Locale, 0),
 	}
-	err := filepath.Walk(path, func(pth string, info os.FileInfo, err error) error {
+	err := vfsutil.Walk(fs, path, func(pth string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -55,7 +56,11 @@ func New(deflt, path string, fs http.FileSystem) (*Lingo, error) {
 		if !strings.HasSuffix(fileName, ".toml") {
 			return nil
 		}
-		dat, err := ioutil.ReadFile(pth)
+		f, err := fs.Open(pth)
+		if err != nil {
+			return err
+		}
+		dat, err := ioutil.ReadAll(f)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The virtual filesystem was being ignored by `New`, which used `filepath.Walk` and `ioutil.ReadFile`, both of which go directly to the native filesystem. This change replaces those calls with ones that use the passed-in `http.FileSystem`; without these changes, the virtual filesystem does nothing.

This will all be obsolete when Go 1.16 is released with the new `go:embed` and `io/fs` functions, but that'll take a while to filter down and until then this change is necessary to have lingo use external embedding tools and `http/FileSystem`.