### PR TITLE
Modified for Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/jdkeke142/lingo-toml
 
-go 1.14
+go 1.16
 
-require (
-	github.com/BurntSushi/toml v0.3.1
-	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
-)
+require github.com/BurntSushi/toml v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
-github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=


### PR DESCRIPTION
With Go 1.16, all of the external FS dependencies are gone. You may want to wait a little before merging this, or put it on its own branch, because it depends on Go 1.16 which may take a bit to reach all of the corners (Arch's package is still 1.15).  In any case, it should be the final change related to the FS stuff now that it's using core libs.